### PR TITLE
Correcciones en flujo de sesion, admin/cliente

### DIFF
--- a/lib/core/config/app_router.dart
+++ b/lib/core/config/app_router.dart
@@ -31,7 +31,7 @@ GoRouter buildGoRouter(RouterType routerType){
 
     if (authCubit.state.userCredential == null) return '/login';
 
-    if (state.matchedLocation == "/" || state.matchedLocation == "/login") return '/feed';
+    if (state.matchedLocation == "/" || state.matchedLocation == "/login") return routerType == RouterType.adminRoute ? '/dashboard' : '/feed';
 
 
     return state.matchedLocation;

--- a/lib/domain/entities/admin.dart
+++ b/lib/domain/entities/admin.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'person.dart';
+
+part 'admin.freezed.dart';
+part 'admin.g.dart';
+
+@freezed
+class Admin with _$Admin {
+
+  const factory Admin({required Person person}) = _Admin;
+
+  factory Admin.fromJson(Map<String, dynamic> json) => _$AdminFromJson(json);
+
+}

--- a/lib/domain/entities/client.dart
+++ b/lib/domain/entities/client.dart
@@ -1,14 +1,15 @@
 
-import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:turni/core/utils/value_transformers.dart';
+
+import 'person.dart';
 
 part 'client.g.dart';
 
 @JsonSerializable()
 class Client {
 
-  Client({this.clientId, this.personId, this.userId});
+  Client({this.clientId, this.personId, this.userId, this.person});
 
 
 
@@ -19,7 +20,12 @@ class Client {
   @JsonKey(name: "user_id", fromJson: ValueTransformers.fromJsonString)
   final String? userId;
 
+  final Person? person;
+
+
+  Map<String, dynamic> toJson() => _$ClientToJson(this);
+  factory Client.fromJson(Map<String,dynamic> json) => _$ClientFromJson(json);
+
        
 
 }
-

--- a/lib/domain/entities/club_partition.dart
+++ b/lib/domain/entities/club_partition.dart
@@ -9,13 +9,7 @@ part 'club_partition.freezed.dart';
 @freezed
 class ClubPartition with _$ClubPartition {
 
-    /*
-        club_partition_id!: number;
-    club_id!: number;
-    club_type_id!: number;
-    phone!: string | null;
- 
-     */
+
     const factory ClubPartition({
       int? club_partition_id,
       required int club_id,

--- a/lib/domain/entities/user.dart
+++ b/lib/domain/entities/user.dart
@@ -1,14 +1,17 @@
 import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
 import 'package:json_annotation/json_annotation.dart';
-import 'package:turni/core/utils/value_transformers.dart';
-import 'package:turni/domain/entities/person.dart';
+import '../../core/utils/value_transformers.dart';
+import 'admin.dart';
+import 'person.dart';
+
+import 'client.dart';
 
 part 'user.g.dart';
 
 @JsonSerializable()
 class User {
 
-  User({this.userId, this.socialId, this.person, this.picture, this.token});
+  User({this.userId, this.socialId, this.picture, this.token, this.client, this.admin});
   
   @JsonKey(name: "user_id", fromJson: ValueTransformers.fromJsonString)
   final String? userId;
@@ -16,21 +19,32 @@ class User {
   @JsonKey(name: "social_id")
   final String? socialId;
   final String? picture;
-  final Person? person;
   final String? token;
 
-  bool isAdmin(){
-    return true;
+  final Client? client;
+  final Admin? admin;
+
+  bool get isAdmin{
+    return admin != null;
   }
 
   factory User.fromGoogleSignInUserData(GoogleSignInUserData userData) => User(
    socialId: userData.id,
-       person: Person(name: userData.displayName!.split(' ')[0], lastName: userData.displayName!.split(' ')[1], email: userData.email)
-    
-  );
+   client: Client(
+    person: Person(name: userData.displayName!.split(' ')[0], lastName: userData.displayName!.split(' ')[1], email: userData.email)
+   ));
 
   Map<String, dynamic> toJson() => _$UserToJson(this);
   factory User.fromJson(Map<String,dynamic> json) => _$UserFromJson(json);
+
+
+  Person get person {
+    if(admin != null){
+       return admin!.person; 
+    }
+
+    return client!.person!;
+  }
         
       
         

--- a/lib/domain/usercases/auth_user_cases.dart
+++ b/lib/domain/usercases/auth_user_cases.dart
@@ -12,7 +12,7 @@ class AuthUserCases {
   * @author Jeremias Manuel
   */
   ///
-  Future login(User user)  async {
+  Future<User> login(User user)  async {
 
     final loggedUser = await authRepository.login(user);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 
@@ -26,16 +27,24 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
 
-    final isAdmin = sl<AuthCubit>().isAdmin();
-
-    return MaterialApp.router(
-      routerConfig: buildGoRouter(isAdmin ? RouterType.adminRoute : RouterType.clientRoute),
-      debugShowCheckedModeBanner: false,
-      title: 'Turni',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Color(0xff672bea), brightness: Brightness.dark),
-        useMaterial3: true,
-      ),
+    
+    return BlocBuilder<AuthCubit, AuthState>(
+      bloc: sl<AuthCubit>(),
+      buildWhen: (previous, current) => previous.userCredential?.isAdmin != current.userCredential?.isAdmin,
+      builder: (context, state) {
+        
+        final isAdmin = sl<AuthCubit>().isAdmin();
+        return MaterialApp.router(
+        routerConfig: buildGoRouter(isAdmin ? RouterType.adminRoute : RouterType.clientRoute),
+        debugShowCheckedModeBanner: false,
+        title: 'Turni',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Color(0xff672bea), brightness: Brightness.dark),
+          useMaterial3: true,
+        ),
+      );
+      },
+      
     );
   }
 }

--- a/lib/presentation/admin/desktop_layout.dart
+++ b/lib/presentation/admin/desktop_layout.dart
@@ -68,7 +68,9 @@ class SideBar extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.end,
           children:[
-            IconButton(onPressed: (){}, icon: const Icon(Icons.logout)),
+            IconButton(onPressed: (){
+              sl<AuthCubit>().signOutGoogle();
+            }, icon: const Icon(Icons.logout)),
             const SizedBox(height: 40,)
           ] 
         ),

--- a/lib/presentation/core/cubit/auth/auth_cubit.dart
+++ b/lib/presentation/core/cubit/auth/auth_cubit.dart
@@ -33,7 +33,7 @@ class AuthCubit extends Cubit<AuthState> with ChangeNotifier {
 
       if( user != null ){
 
-        authUserCases.login(user);
+        //authUserCases.login(user);
         emit(AuthLogged(userCredential: user));
 
       } else {
@@ -61,6 +61,7 @@ class AuthCubit extends Cubit<AuthState> with ChangeNotifier {
   void signOutGoogle() async {
 
     emit(const AuthNotLogged());
+    await authUserCases.logout();
     notifyListeners();
   }
 
@@ -69,9 +70,9 @@ class AuthCubit extends Cubit<AuthState> with ChangeNotifier {
 
     final user = User.fromGoogleSignInUserData(userData);
 
-    authUserCases.login(user);
-
-    emit(AuthLogged(userCredential: user));
+    final completeUser = await authUserCases.login(user);
+    
+    print(user.admin?.person.name);    emit(AuthLogged(userCredential: completeUser));
 
     notifyListeners();
 
@@ -82,8 +83,10 @@ class AuthCubit extends Cubit<AuthState> with ChangeNotifier {
   }
 
   bool isAdmin(){
-    return /* state.userCredential?.isAdmin() ?? */ true;
+    return  state.userCredential?.isAdmin ?? false;
   }
+
+
 }
 
 


### PR DESCRIPTION
## Descripción

Se actualizaron entidades 'user' y 'client' para que sus datos sean como los provee el ORM, para alinearnos mas al back y que trabajemos mas comodos

Cree entidad Admin

Complete el flujo que determina en la aplicacion si el usuario logeado es admin o cliente, y crea el router de cada uno

Agregue funcionalidad de logout en botón del layout de admin

Corregí error que ocurría al logearse, que emitía un usuario que no era el que el backend nos devolvía, el cual se encontraba incompleto




| Hotfix | Master | Squash&Merge | 

