### PR TITLE
Feature/funcionalidad extra session manager

### DIFF
--- a/lib/core/config/app_router.dart
+++ b/lib/core/config/app_router.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:turni/core/config/service_locator.dart';
 import 'package:turni/domain/entities/session.dart';
 import 'package:turni/presentation/admin/session_manager_screen/sessions_manager.dart';
@@ -18,9 +19,11 @@ import '../../presentation/admin/create_session_screen/create_sessions_screen.da
 
 
 import '../../domain/entities/club_type.dart';
+import '../../presentation/admin/session_manager_screen/widgets/add_new_session.dart';
 import '../../presentation/admin/session_manager_screen/widgets/calendar_side_column.dart';
 import '../../presentation/home/home.dart';
 import '../../presentation/session_feed/session_feed.dart';
+import '../utils/types/time_interval.dart';
 
 enum RouterType { clientRoute, adminRoute }
 
@@ -32,6 +35,7 @@ GoRouter buildGoRouter(RouterType routerType) {
     initialLocation: '/',
     refreshListenable: sl<AuthCubit>(),
     redirect: (context, state) {
+
       final authCubit = sl<AuthCubit>();
 
       if (authCubit.getLoadingStatus()) return '/';
@@ -42,7 +46,6 @@ GoRouter buildGoRouter(RouterType routerType) {
         return routerType == RouterType.adminRoute ? '/dashboard' : '/feed';
       }
 
-      return state.matchedLocation;
     },
     routes: [
       /// Estas dos rutas son comunes a ambos tipos de usuario.
@@ -122,19 +125,38 @@ List<StatefulShellBranch> buildBranches(RouterType routerType) {
                   GoRoute(
                     path: '/session_manager/reserve',
                     pageBuilder: (context, state) {
-                      return const  NoTransitionPage(child: SizedBox(width: 300, child: Text("reservar turno"),));
+                      return const  NoTransitionPage(child: Text("reservar turno"));
                     },
                   ),    
                   GoRoute(
                     path: '/session_manager/edit',
                     pageBuilder: (context, state) {
-                      return const  NoTransitionPage(child: SizedBox(width: 300, child: Text("Editar turno"),));
+                      return const  NoTransitionPage(child: Text("Editar turno"));
                     },
                   ),
                   GoRoute(
-                    path: '/session_manager/add',
+                    path: '/session_manager/add/:idPhysicalPartition',
+                    name: "SESSION_MANAGER_ADD",
                     pageBuilder: (context, state) {
-                      return const  NoTransitionPage(child: SizedBox(width: 300, child: Text("Agregar turno"),));
+                      
+                      final idPhysicalPartition = state.pathParameters['idPhysicalPartition'];
+
+                      final startTime = state.uri.queryParameters['start'];
+                      final endTime = state.uri.queryParameters['end'];
+
+                      DateFormat dateFormat = DateFormat("HH:mm");
+
+                      final timeInterval = TimeInterval(
+                        initialDate: startTime != null ? dateFormat.parse(startTime) : null,
+                        endDate: endTime != null ? dateFormat.parse(endTime) : null
+                      );
+
+                      return NoTransitionPage(
+                        child: AddNewSession(
+                          idPhysicalPartition: int.parse(idPhysicalPartition!), 
+                          selectedTimeInterval: timeInterval
+                        )
+                      );
                     },
                   ),
                 ], 

--- a/lib/core/utils/types/time_interval.dart
+++ b/lib/core/utils/types/time_interval.dart
@@ -45,6 +45,24 @@ class TimeInterval {
     return 'TimeInterval(initialDate: $initialDate, endDate: $endDate)';
   }
 
+  String toStringTime(){
+
+    final initialTime = initialDate != null ? DateFormat.Hm().format(initialDate!) : '';
+    final endTime = initialDate != null ? DateFormat.Hm().format(endDate!) : '';
+
+    return '$initialTime - $endTime';
+
+  }
+
+  Duration? getDuration(){
+    
+    if(initialDate != null && endDate != null){
+      return endDate!.difference(initialDate!);
+    }
+
+    return null;
+  }
+
   List<DateTime> generateDateRange() {
     
   List<DateTime> dateRange = [];

--- a/lib/domain/entities/person.dart
+++ b/lib/domain/entities/person.dart
@@ -22,6 +22,9 @@ class Person {
   
   factory Person.fromJson(Map<String, dynamic> json) => _$PersonFromJson(json);
 
+
+  String get fullName => "$name $lastName";
+
   
 
 }

--- a/lib/domain/entities/physical_partition.dart
+++ b/lib/domain/entities/physical_partition.dart
@@ -21,7 +21,8 @@ class PhysicalPartition with _$PhysicalPartition {
     required int? physicalIdentifier,
     @JsonKey(name: "is_cover") 
     required String? isCover, 
-    required String? description
+    required String? description,
+    @JsonKey(defaultValue: 90) int? durationInMinutes
   }
   ) = _PhysicalPartition;
 

--- a/lib/domain/entities/session.dart
+++ b/lib/domain/entities/session.dart
@@ -1,5 +1,6 @@
 
 
+import 'package:calendar_view/calendar_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -19,8 +20,8 @@ class Session with _$Session{
     required DateTime createdAt, 
     @JsonKey(name: "start_time", fromJson: ValueTransformers.fromJsonDateTimeLocale)
     required DateTime startTime, 
-    @JsonKey(defaultValue: "1:30")
-    required String duration, 
+    @JsonKey(defaultValue: 90)
+    required int duration, 
     @JsonKey(name: "client_id")
     int? clientId, 
 
@@ -38,9 +39,9 @@ class Session with _$Session{
 
 
   getDurationInMinutes() {
-    final [hours, minutes] = duration.split(':');
 
-    return (int.parse(hours) * 60) + int.parse(minutes);
+    return duration;
+    
   }
 
   static Session fromDates(DateTime startTime, TimeOfDay duration){
@@ -48,7 +49,7 @@ class Session with _$Session{
       sessionId: 1,
       createdAt: DateTime.now(), 
       startTime: startTime, 
-      duration: "${duration.hour}:${duration.minute}", 
+      duration: duration.getTotalMinutes, //"${duration.hour}:${duration.minute}", 
       price: 1500, 
       adminCreatorId: 1,
       partitionPhysicalId: 1

--- a/lib/domain/repositories/session_repository.dart
+++ b/lib/domain/repositories/session_repository.dart
@@ -16,4 +16,6 @@ abstract class SessionRepository {
   Future<List<ClubPartition>> getPhysicalPartitions();
 
   createSessions(List<Session> sessions, List<int> physicalPartitions, List<DateTime> dates);
+
+  Future<Session> saveSession(Session session);
 }

--- a/lib/domain/usercases/session_user_cases.dart
+++ b/lib/domain/usercases/session_user_cases.dart
@@ -19,5 +19,9 @@ class SessionUserCases {
    return _sessionRepository.createSessions(sessions, physicalPartitions, interval.generateDateRange());
   }
 
+  Future<Session> saveSession(Session session) async {
+   return _sessionRepository.saveSession(session);
+  }
+
 
 }

--- a/lib/infrastructure/api/providers/session_provider.dart
+++ b/lib/infrastructure/api/providers/session_provider.dart
@@ -71,4 +71,20 @@ class SessionProvider {
       return false;      
     }
   }
+
+  Future<Session> saveSession(Session session) async {
+
+  try {
+      final body = {
+        "session":session,
+      };
+
+      final response = await dioInstance.post("/admin/session", data: body);
+
+      return Session.fromJson(response.data);
+
+    } catch (e) {      
+      return Session.fromJson({});;      
+    }
+  }
 }

--- a/lib/infrastructure/api/repositories/session_repository_impl.dart
+++ b/lib/infrastructure/api/repositories/session_repository_impl.dart
@@ -34,4 +34,9 @@ class SessionRepositoryImplementation extends SessionRepository {
   createSessions(List<Session> sessions, List<int> physicalPartitions, List<DateTime> dates) {
     return sessionProvider.createSessions(sessions, physicalPartitions, dates);
   }
+  
+  @override
+  Future<Session> saveSession(Session session) {
+    return sessionProvider.saveSession(session);
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,7 +46,7 @@ class MyApp extends StatelessWidget {
         debugShowCheckedModeBanner: false,
         title: 'Turni',
         theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xff672bea), brightness: Brightness.light),
+          colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xff672bea), brightness: Brightness.dark),
           useMaterial3: true,
         ),
       );

--- a/lib/presentation/admin/bloc/session_manager_bloc.dart
+++ b/lib/presentation/admin/bloc/session_manager_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:bloc/bloc.dart';
+import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -7,7 +8,6 @@ import '../../../domain/entities/session.dart';
 import '../../../domain/usercases/session_user_cases.dart';
 import '../../../infrastructure/api/providers/session_provider.dart';
 import '../../../infrastructure/api/repositories/session_repository_impl.dart';
-import '../../../infrastructure/api/repositories/session_repository_test.dart';
 import '../../core/dates_carrousel/dates_carrousel.dart';
 import 'session_manager_event.dart';
 import 'session_manager_state.dart';
@@ -89,9 +89,23 @@ class SessionManagerBloc extends Bloc<SessionManagerEvent, SessionManagerState> 
 
     },);
 
+    
+    on<SaveSessionEvent>((event, emit) async {
+
+      final session = await _sessionUserCases.saveSession(event.session);
+
+      emit(
+        state.copyWith(
+          sessions: [...state.sessions, session].sorted((a, b) => a.startTime.isAfter(b.startTime) ? 1 : 0,)
+        )
+      );
+      
+    });
+
     add(SessionLoadEvent());
 
 
   }
+
   
 }

--- a/lib/presentation/admin/bloc/session_manager_event.dart
+++ b/lib/presentation/admin/bloc/session_manager_event.dart
@@ -4,6 +4,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../../../domain/entities/club_partition.dart';
+import '../../../domain/entities/session.dart';
 
 part 'session_manager_event.freezed.dart';
 
@@ -17,6 +18,8 @@ class SessionManagerEvent with _$SessionManagerEvent {
   factory SessionManagerEvent.changeClubPartition(ClubPartition newClubPartition) = ChangeClubPartitionEvent;
 
   factory SessionManagerEvent.reloadSessionsEvent() = ReloadSessionsEvent;
+
+  factory SessionManagerEvent.saveSession(Session session) = SaveSessionEvent;
 
 
 }

--- a/lib/presentation/admin/create_session_screen/widgets/agenda_edit_card.dart
+++ b/lib/presentation/admin/create_session_screen/widgets/agenda_edit_card.dart
@@ -1,3 +1,4 @@
+import 'package:calendar_view/calendar_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_portal/flutter_portal.dart';
 import 'package:intl/intl.dart';
@@ -31,7 +32,7 @@ class _AgendaEditCardState extends State<AgendaEditCard> {
         onSave: (initialTime, duration){
           dropdownController.hide!();
           sl<CreateSesssionsFormBloc>().add(
-            EditSession(widget.session, widget.session.copyWith(startTime: DateTime.now().applied(initialTime), duration: "${duration.hour}:${duration.minute}"))
+            EditSession(widget.session, widget.session.copyWith(startTime: DateTime.now().applied(initialTime), duration: duration.getTotalMinutes))
           );
         },
         onCancel: () => dropdownController.hide!(),

--- a/lib/presentation/admin/create_session_screen/widgets/session_form_dropdown.dart
+++ b/lib/presentation/admin/create_session_screen/widgets/session_form_dropdown.dart
@@ -77,8 +77,8 @@ class _SessionFormDropdownState extends State<SessionFormDropdown> {
                       const SizedBox(height: 16,),
                       CustomTimePicker(
                         name: "duration",
-                        initialHours: widget.session?.duration != null ? widget.session?.duration.split(":")[0] : null,
-                        initialMinutes: widget.session?.duration != null ? widget.session?.duration.split(":")[1] : null,
+                        initialHours: ((widget.session?.duration ?? 0) ~/ 60).toString(),
+                        initialMinutes: widget.session?.duration != null ? (widget.session!.duration % 60).toString() : null,
                         onSubmit: onSubmit,      
                         isLastInput: true,
                       )

--- a/lib/presentation/admin/session_manager_screen/sessions_manager.dart
+++ b/lib/presentation/admin/session_manager_screen/sessions_manager.dart
@@ -58,7 +58,10 @@ class SessionsManager extends StatelessWidget {
         const SizedBox(
           width: 16,
         ),
-        sideChild
+        SizedBox(
+          width: 300,
+          child: sideChild
+        )
       ],
     );
   }

--- a/lib/presentation/admin/session_manager_screen/sessions_manager.dart
+++ b/lib/presentation/admin/session_manager_screen/sessions_manager.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import '../../../core/config/service_locator.dart';
 import '../../../core/utils/responsive_builder.dart';
 import '../../../core/utils/types/time_interval.dart';
@@ -28,11 +30,22 @@ class SessionsManager extends StatelessWidget {
       buildWhen: (previous, current) =>
           previous.isFirstLoad != current.isFirstLoad,
       builder: (context, state) {
+
         if (state.isFirstLoad) {
           return const Center(
             child: CircularProgressIndicator(),
           );
         }
+        print(GoRouter.of(context).routeInformationProvider.value.uri.toString() == '/session_manager');
+       if(ResponsiveBuilder.isMobile(context) && GoRouter.of(context).routeInformationProvider.value.uri.toString() != '/session_manager'){
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: sideChild,
+          );
+        } 
+
+       
+    
     
         if (ResponsiveBuilder.isMobile(context)) {
           return buildAgendaContainer(context);
@@ -43,26 +56,26 @@ class SessionsManager extends StatelessWidget {
     );
   }
 
-  Row buildDesktopManager(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.end,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
+  Padding buildDesktopManager(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
             child: buildAgendaContainer(context),
           ),
-        ),
-        const VerticalDivider(),
-        const SizedBox(
-          width: 16,
-        ),
-        SizedBox(
-          width: 300,
-          child: sideChild
-        )
-      ],
+          const VerticalDivider(),
+          const SizedBox(
+            width: 16,
+          ),
+          SizedBox(
+            width: 300,
+            child: sideChild
+          )
+        ],
+      ),
     );
   }
 
@@ -70,9 +83,9 @@ class SessionsManager extends StatelessWidget {
     return Column(
       children: [
         if (ResponsiveBuilder.isMobile(context))
-          const Padding(
-            padding:  EdgeInsets.all(8.0),
-            child: SizedBox(height: 50, child: SessionManagerDayCarrousel()),
+          Padding(
+            padding: const  EdgeInsets.all(8.0),
+            child: SizedBox(height: 50, child: SessionManagerDayCarrousel(width: MediaQuery.of(context).size.width * 0.9,)),
           ),
         SizedBox(
           height: 40,
@@ -151,7 +164,7 @@ class SessionsManager extends StatelessWidget {
 
         return Agenda(
           columnWidth: 200,
-          heightPerMinute: ResponsiveBuilder.isDesktop(context) ? 1.35 : 1,
+          heightPerMinute: ResponsiveBuilder.isDesktop(context) ? 1.35 : 1.1,
           fromDate: state.currentDate.applied(const TimeOfDay(hour: 8, minute: 0)),
           lastDate: state.currentDate.applied(const TimeOfDay(hour: 22, minute: 0)),
           buildCard: (session) {

--- a/lib/presentation/admin/session_manager_screen/widgets/add_new_session.dart
+++ b/lib/presentation/admin/session_manager_screen/widgets/add_new_session.dart
@@ -1,0 +1,201 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/config/service_locator.dart';
+import '../../../../core/utils/types/time_interval.dart';
+import '../../../../domain/entities/client.dart';
+import '../../../../domain/entities/person.dart';
+import '../../../../domain/entities/physical_partition.dart';
+import '../../../core/custom_time_picker.dart';
+import '../../bloc/session_manager_bloc.dart';
+import 'calendar_side_column.dart';
+
+class AddNewSession extends StatelessWidget {
+
+  AddNewSession({
+    super.key, 
+    required int idPhysicalPartition,
+    required this.selectedTimeInterval
+  }) : physicalPartition = _findPhysicalPartition(idPhysicalPartition),
+       duration = selectedTimeInterval.getDuration();
+
+  final PhysicalPartition physicalPartition;
+  final TimeInterval selectedTimeInterval;
+  final Duration? duration; 
+
+  static PhysicalPartition _findPhysicalPartition(int idPhysicalPartition){
+
+    return sl<SessionManagerBloc>().state.clubPartitions.firstWhere((element) {
+
+      final index = element.physicalPartitions!.indexWhere((element) => element.partitionPhysicalId == idPhysicalPartition,);
+
+      return index != -1;
+    })
+    .physicalPartitions!.firstWhere((element) => element.partitionPhysicalId == idPhysicalPartition,);
+
+  }
+
+  final GlobalKey<FormBuilderState> _formKey = GlobalKey<FormBuilderState>();
+
+ 
+
+  @override
+  Widget build(BuildContext context) {
+    return FormBuilder(
+      key: _formKey,
+      child: Column(
+        children: [
+          Row(
+            children: [
+              IconButton(
+                onPressed: (){
+                  context.go("/session_manager");
+                }, 
+                icon: const Icon(Icons.arrow_back)
+              ),
+              const Spacer(),
+              Text("Nuevo Turno ${selectedTimeInterval.toStringTime()}",),
+              const Spacer(),
+            ],
+          ),
+          const SizedBox(height: 64),
+          InputChip(label: Text("Cancha ${physicalPartition.physicalIdentifier}")),
+          const SizedBox(height: 16),
+          const Divider(),
+          const SizedBox(height: 16),
+          const Text("Cliente"),
+          const SizedBox(height: 16),
+          const PickClient(),
+          const SizedBox(height: 16),
+          const Divider(),
+          const SizedBox(height: 16),
+          const Text("Hora de inicio"),
+          const SizedBox(height: 16),
+          CustomTimePicker(
+            name: "timepicker",
+            initialHours: selectedTimeInterval.initialDate!.hour.toString(),
+            initialMinutes: selectedTimeInterval.initialDate!.minute.toString(),
+          ),
+          const SizedBox(height: 16),
+          const Text("Duracion"),
+          const SizedBox(height: 16),
+          CustomTimePicker(
+            name: "timepicker",
+            initialHours: duration?.inHours.toString(),
+            initialMinutes: (duration!.inMinutes - duration!.inHours * 60).toString(),
+          ),
+          const SizedBox(height: 16),
+
+        ],
+      ),
+    );
+  }
+}
+
+
+
+class PickClient extends StatefulWidget {
+  const PickClient({super.key});
+
+  @override
+  State<PickClient> createState() => _PickClientState();
+}
+
+class _PickClientState extends State<PickClient> {
+
+  Client? pickedClient;
+  final SearchController _searchController = SearchController();
+
+  @override
+
+
+  @override
+  Widget build(BuildContext context) {
+    
+    if(pickedClient == null) {
+      return Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              SearchAnchor(
+                searchController: _searchController,
+                builder: (context, controller) {
+                return FilledButton(
+                  
+                  onPressed: () {
+                  _searchController.openView();
+                },
+                child: Row(
+                  children: [
+                    Icon(Icons.search),
+                    Text("Buscar"),
+                  ],
+                )
+                );
+              }, 
+              suggestionsBuilder: (context, controller) {
+                final clients = [
+                  "Pedro Alfonso",
+                  "Guido CHiara",
+                  "Agustin masa",
+                  "Joaquin Mastropierro",
+                  "Lucas Medico",
+                  "Esteban ",
+                  "XD ",
+                  "Guido CHiara",
+                  "Agustin masa",
+                  "Joaquin Mastropierro",
+                  "Lucas Medico",
+                ];
+
+                
+              
+                return clients
+                .where((element) => element.contains(controller.text),)
+                .map((client) => InkWell(
+                  onTap: () {
+                    _searchController.closeView(null);
+                    setState(() {
+                      pickedClient = Client(
+                        person: Person(name: "Agustin", lastName: "Massa", email: "masa", phone: "223412323")
+                      );
+                    });
+                  },
+                  child: ListTile(
+                    leading: CircleAvatar(
+                      child: Text(client.characters.first)
+                      ),
+                    subtitle: Text("2284690141"),
+                    title: Text(client),
+                  ),
+                ),);
+              },),
+              OutlinedButton(onPressed: (){}, child: Row(children: [Icon(Icons.add) ,Text("Crear")],), )
+            ],
+          );
+    }
+
+    return Row(
+      children: [
+        Expanded(
+          child: ListTile(
+                        leading: CircleAvatar(
+                          child: Text(pickedClient!.person!.fullName.characters.first)
+                          ),
+                        subtitle: Text(pickedClient!.person!.phone!),
+                        title: Text(pickedClient!.person!.fullName),
+                      ),
+        ),
+        IconButton(
+          onPressed: (){
+            setState(() {
+              pickedClient = null;
+            });
+          },
+          icon: const Icon(Icons.close)
+        )
+      ],
+    );
+  }
+}

--- a/lib/presentation/admin/session_manager_screen/widgets/add_new_session.dart
+++ b/lib/presentation/admin/session_manager_screen/widgets/add_new_session.dart
@@ -1,201 +1,444 @@
-import 'package:collection/collection.dart';
+import 'package:calendar_view/calendar_view.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/config/service_locator.dart';
 import '../../../../core/utils/types/time_interval.dart';
 import '../../../../domain/entities/client.dart';
+import '../../../../domain/entities/club_partition.dart';
 import '../../../../domain/entities/person.dart';
 import '../../../../domain/entities/physical_partition.dart';
+import '../../../../domain/entities/session.dart';
 import '../../../core/custom_time_picker.dart';
 import '../../bloc/session_manager_bloc.dart';
-import 'calendar_side_column.dart';
+import '../../bloc/session_manager_event.dart';
 
-class AddNewSession extends StatelessWidget {
+class AddNewSession extends StatefulWidget {
+  AddNewSession(
+      {super.key,
+      required int idPhysicalPartition,
+      required this.selectedTimeInterval})
+      : clubPartition = _findPhysicalPartition(idPhysicalPartition){
 
-  AddNewSession({
-    super.key, 
-    required int idPhysicalPartition,
-    required this.selectedTimeInterval
-  }) : physicalPartition = _findPhysicalPartition(idPhysicalPartition),
-       duration = selectedTimeInterval.getDuration();
+        physicalPartition = clubPartition.physicalPartitions!.firstWhere(
+          (element) => element.partitionPhysicalId == idPhysicalPartition,
+        );
 
-  final PhysicalPartition physicalPartition;
-  final TimeInterval selectedTimeInterval;
-  final Duration? duration; 
-
-  static PhysicalPartition _findPhysicalPartition(int idPhysicalPartition){
-
-    return sl<SessionManagerBloc>().state.clubPartitions.firstWhere((element) {
-
-      final index = element.physicalPartitions!.indexWhere((element) => element.partitionPhysicalId == idPhysicalPartition,);
-
-      return index != -1;
-    })
-    .physicalPartitions!.firstWhere((element) => element.partitionPhysicalId == idPhysicalPartition,);
-
+        duration = physicalPartition.durationInMinutes != null ? Duration(minutes: physicalPartition.durationInMinutes!) : selectedTimeInterval.getDuration();
   }
 
+  late final PhysicalPartition physicalPartition;
+  final ClubPartition clubPartition;
+  final TimeInterval selectedTimeInterval;
+  late final Duration? duration;
   final GlobalKey<FormBuilderState> _formKey = GlobalKey<FormBuilderState>();
 
- 
+  static ClubPartition _findPhysicalPartition(int idPhysicalPartition) {
+    return sl<SessionManagerBloc>().state.clubPartitions.firstWhere((element) {
+      final index = element.physicalPartitions!.indexWhere(
+        (element) => element.partitionPhysicalId == idPhysicalPartition,
+      );
+
+      return index != -1;
+    });
+  }
+
+  @override
+  State<AddNewSession> createState() => _AddNewSessionState();
+}
+
+class _AddNewSessionState extends State<AddNewSession> {
+
+  bool isValid = true;
 
   @override
   Widget build(BuildContext context) {
     return FormBuilder(
-      key: _formKey,
+      autovalidateMode: AutovalidateMode.onUserInteraction,
+      key: widget._formKey,
+      onChanged: (){
+        
+        setState(() {
+          isValid = widget._formKey.currentState!.validate(focusOnInvalid: false);
+        });
+      },
       child: Column(
-        children: [
-          Row(
-            children: [
-              IconButton(
-                onPressed: (){
-                  context.go("/session_manager");
-                }, 
-                icon: const Icon(Icons.arrow_back)
+        children: [          
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                children: [
+                  buildHeader(context),
+                  const SizedBox(height: 32),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      InputChip(
+                        label: Text(widget.clubPartition.clubType!.name)
+                      ),
+                      const SizedBox(
+                        width: 8,
+                      ),
+                      InputChip(
+                          label: Text("Cancha ${widget.physicalPartition.physicalIdentifier}")
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  const Divider(),
+                  const SizedBox(height: 16),
+                  PickClient(
+                    onPressNew: () {
+                      setState(() {
+                        isValid = widget._formKey.currentState!.validate(focusOnInvalid: false);
+                      });
+                    },
+                    onBackToSelection: () {
+                      setState(() {
+                        isValid = widget._formKey.currentState!.validate(focusOnInvalid: false);
+                      });
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  const Divider(),
+                  const SizedBox(height: 16),
+                  const Text("Hora de inicio"),
+                  const SizedBox(height: 16),
+                  CustomTimePicker(
+                    name: "initialTime",
+                    initialHours: widget.selectedTimeInterval.initialDate!.hour.toString(),
+                    initialMinutes: widget.selectedTimeInterval.initialDate!.minute.toString(),
+                  ),
+                  const SizedBox(height: 16),
+                  const Text("Duracion"),
+                  const SizedBox(height: 16),
+                  CustomTimePicker(
+                    name: "duration",
+                    initialHours: widget.duration?.inHours.toString(),
+                    initialMinutes:
+                        (widget.duration!.inMinutes - widget.duration!.inHours * 60).toString(),
+                    
+                  ),
+                  const SizedBox(height: 16),
+                  const Divider(),
+                  const SizedBox(height: 16),
+                  SizedBox(
+                    width: 220,
+                    child: FormBuilderTextField(
+                      name: "price",
+                      decoration: InputDecoration(
+                        prefix: Text("\$"),
+                        border: const OutlineInputBorder(),
+                        filled: true,
+                        fillColor: Theme.of(context).colorScheme.surface,
+                        labelText: "Precio",                                        
+                      ),
+                      inputFormatters: [
+                        FilteringTextInputFormatter.digitsOnly
+                      ],
+                    ),
+                  )
+                  
+                ],
               ),
-              const Spacer(),
-              Text("Nuevo Turno ${selectedTimeInterval.toStringTime()}",),
-              const Spacer(),
-            ],
+            ),
           ),
-          const SizedBox(height: 64),
-          InputChip(label: Text("Cancha ${physicalPartition.physicalIdentifier}")),
-          const SizedBox(height: 16),
-          const Divider(),
-          const SizedBox(height: 16),
-          const Text("Cliente"),
-          const SizedBox(height: 16),
-          const PickClient(),
-          const SizedBox(height: 16),
-          const Divider(),
-          const SizedBox(height: 16),
-          const Text("Hora de inicio"),
-          const SizedBox(height: 16),
-          CustomTimePicker(
-            name: "timepicker",
-            initialHours: selectedTimeInterval.initialDate!.hour.toString(),
-            initialMinutes: selectedTimeInterval.initialDate!.minute.toString(),
-          ),
-          const SizedBox(height: 16),
-          const Text("Duracion"),
-          const SizedBox(height: 16),
-          CustomTimePicker(
-            name: "timepicker",
-            initialHours: duration?.inHours.toString(),
-            initialMinutes: (duration!.inMinutes - duration!.inHours * 60).toString(),
-          ),
-          const SizedBox(height: 16),
+          Padding(
+            padding: const EdgeInsets.only(top:16),
+            child: FilledButton(
+              onPressed: isValid ? (){
 
+                final sessionManagerBloc = sl<SessionManagerBloc>();
+
+                final currentDate = sessionManagerBloc.state.currentDate;
+
+                final values = widget._formKey.currentState?.instantValue;
+         
+                TimeOfDay duration = values!['duration'];
+
+                final newSession = Session(
+                  sessionId: -1,
+                  createdAt: DateTime.now(),
+                  startTime: currentDate.applied(values['initialTime']), 
+                  duration: duration.getTotalMinutes,
+                  price: values['price'] != null ? double.parse(values['price']) : 0, 
+                  partitionPhysicalId: widget.physicalPartition.partitionPhysicalId
+                );
+
+                sessionManagerBloc.add(
+                  SaveSessionEvent(newSession)
+                );
+
+                context.go("/session_manager");
+              } : null,
+              child: const Text("Crear Turno")
+            ),
+          )
         ],
       ),
     );
   }
+
+  Stack buildHeader(BuildContext context) {
+    return Stack(
+                  children: [
+                    SizedBox(
+                      height: 64,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text("Nuevo Turno ${widget.selectedTimeInterval.toStringTime()}", style: const TextStyle(fontSize: 16),)
+                        ],
+                      ),
+                    ),
+                    SizedBox(
+                      height: 64,
+                      child: IconButton(
+                        onPressed: (){
+                          context.go("/session_manager");
+                        }, 
+                        icon: const Icon(Icons.arrow_back)
+                      ),
+                    ),
+                    
+                  ],
+                );
+  }
 }
 
-
-
 class PickClient extends StatefulWidget {
-  const PickClient({super.key});
+  const PickClient({super.key,
+  this.onPressNew, 
+  this.onBackToSelection, 
+  this.onSelect
+  });  
+  
+  /// Invocado cuando se preciona en "Nuevo" cliente.
+  final Function()? onPressNew;
+  /// Invocado al volver a la etapa inicial del componente.
+  final Function()? onBackToSelection;
+  /// Invocado al seleccionar un cliente existente desde la etapa inicial.
+  final Function()? onSelect;
 
   @override
   State<PickClient> createState() => _PickClientState();
 }
 
 class _PickClientState extends State<PickClient> {
-
   Client? pickedClient;
   final SearchController _searchController = SearchController();
+  bool newMode = false;
 
   @override
-
-
   @override
   Widget build(BuildContext context) {
-    
-    if(pickedClient == null) {
-      return Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              SearchAnchor(
-                searchController: _searchController,
-                builder: (context, controller) {
-                return FilledButton(
-                  
-                  onPressed: () {
-                  _searchController.openView();
-                },
-                child: Row(
-                  children: [
-                    Icon(Icons.search),
-                    Text("Buscar"),
-                  ],
-                )
-                );
-              }, 
-              suggestionsBuilder: (context, controller) {
-                final clients = [
-                  "Pedro Alfonso",
-                  "Guido CHiara",
-                  "Agustin masa",
-                  "Joaquin Mastropierro",
-                  "Lucas Medico",
-                  "Esteban ",
-                  "XD ",
-                  "Guido CHiara",
-                  "Agustin masa",
-                  "Joaquin Mastropierro",
-                  "Lucas Medico",
-                ];
+    final children = [
+      if(!newMode)
+      const Text("Cliente"),
+      if(newMode) Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Text("Nuevo Cliente"),
+          const Spacer(),
+          IconButton(
+            onPressed: () {
+              setState(() {
+                newMode = false;
+              });
 
-                
+              WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                widget.onBackToSelection?.call();
+              });
               
-                return clients
-                .where((element) => element.contains(controller.text),)
-                .map((client) => InkWell(
-                  onTap: () {
-                    _searchController.closeView(null);
-                    setState(() {
-                      pickedClient = Client(
-                        person: Person(name: "Agustin", lastName: "Massa", email: "masa", phone: "223412323")
-                      );
-                    });
-                  },
-                  child: ListTile(
-                    leading: CircleAvatar(
-                      child: Text(client.characters.first)
+
+            },
+            icon: const Icon(Icons.close)
+          )
+          
+      ]),
+      const SizedBox(height: 16),
+    ];
+    
+    if (pickedClient == null && !newMode) {
+      children.add(Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          SearchAnchor(
+            searchController: _searchController,
+            builder: (context, controller) {
+              return FilledButton.icon(onPressed: (){
+                _searchController.openView();
+              }, 
+              label: const Text("buscar"),
+              icon: const Icon(Icons.search),
+            );
+            },
+            suggestionsBuilder: (context, controller) {
+              final clients = [
+                "Mailen Fioravanti",
+                "Guido CHiara",
+                "Agustin masa",
+                "Joaquin Mastropierro",
+                "Lucas Medico",
+                "Esteban ",
+                "XD ",
+                "Guido CHiara",
+                "Agustin masa",
+                "Joaquin Mastropierro",
+                "Lucas Medico",
+              ];
+
+              return clients
+                  .where(
+                    (element) => element.contains(controller.text),
+                  )
+                  .map(
+                    (client) => InkWell(
+                      onTap: () {
+                        _searchController.closeView(null);
+                        setState(() {
+                          pickedClient = Client(
+                              person: Person(
+                                  name: "Agustin",
+                                  lastName: "Massa",
+                                  email: "masa",
+                                  phone: "223412323"));
+                        });
+                      },
+                      child: ListTile(
+                        leading:
+                            CircleAvatar(child: Text(client.characters.first)),
+                        subtitle: Text("2284690141"),
+                        title: Text(client),
                       ),
-                    subtitle: Text("2284690141"),
-                    title: Text(client),
-                  ),
-                ),);
-              },),
-              OutlinedButton(onPressed: (){}, child: Row(children: [Icon(Icons.add) ,Text("Crear")],), )
-            ],
-          );
+                    ),
+                  );
+            },
+          ),
+          OutlinedButton.icon(
+            icon: const Icon(Icons.add),
+            label: const Text("Crear"),
+            onPressed: () {
+              setState(() {
+                newMode = true;
+              });
+
+              WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                widget.onPressNew?.call();
+              });
+              
+            }
+          )
+        ],
+      ));
     }
 
-    return Row(
-      children: [
-        Expanded(
-          child: ListTile(
-                        leading: CircleAvatar(
-                          child: Text(pickedClient!.person!.fullName.characters.first)
-                          ),
-                        subtitle: Text(pickedClient!.person!.phone!),
-                        title: Text(pickedClient!.person!.fullName),
-                      ),
-        ),
-        IconButton(
-          onPressed: (){
-            setState(() {
-              pickedClient = null;
-            });
-          },
-          icon: const Icon(Icons.close)
-        )
-      ],
+    if(pickedClient != null){
+      children.add(
+        ListTile(  
+        leading: CircleAvatar(
+            child: Text(pickedClient!.person!.fullName.characters.first)
+          ),
+        trailing: IconButton(
+            onPressed: () {
+              setState(() {
+                pickedClient = null;
+              });
+            },
+            icon: const Icon(Icons.close)
+          ),
+        subtitle: Text(pickedClient!.person!.phone!),
+        title: Text(pickedClient!.person!.fullName),
+      ));
+    } 
+
+    if(pickedClient == null && newMode){
+      children.add(
+        Column(
+        children: [
+          FormBuilderTextField(
+            autofocus: true,
+            validator: requiredAndMin3,
+            name: "name", 
+            decoration: InputDecoration(
+              prefixIcon: const Icon(Icons.person, size: 14,),
+              border: const OutlineInputBorder(),
+              filled: true,
+              fillColor: Theme.of(context).colorScheme.surface,
+              helperText: "Obligatorio",
+              labelText: "Nombre",
+              
+              
+            ),
+          ),
+          const SizedBox(height: 16,),
+          FormBuilderTextField(
+            name: "lastname", 
+            validator: requiredAndMin3,
+            decoration: InputDecoration(
+              prefixIcon: const Icon(Icons.person, size: 14,),
+              border: const OutlineInputBorder(),
+              filled: true,
+              fillColor: Theme.of(context).colorScheme.surface,
+              helperText: "Obligatorio",
+              labelText: "Apellido"        
+            ),
+          ),
+          const SizedBox(height: 16,),
+          FormBuilderTextField(
+            validator: requiredAndMin3,
+            name: "phone", 
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'[0-9]')), 
+              // for version 2 and greater youcan also use this
+              FilteringTextInputFormatter.digitsOnly
+
+            ],
+            
+            decoration: InputDecoration(
+              prefixIcon: const Icon(Icons.phone, size: 14,),
+              border: const OutlineInputBorder(),
+              filled: true,
+              fillColor: Theme.of(context).colorScheme.surface,
+              helperText: "Obligatorio",
+              labelText: "Telefono",
+              
+                
+            ),
+          ),
+          const SizedBox(height: 16,),
+          FormBuilderTextField(
+            name: "email", 
+            decoration: InputDecoration(
+              prefixIcon: const Icon(Icons.mail, size: 14,),
+              border: const OutlineInputBorder(),
+              filled: true,
+              fillColor: Theme.of(context).colorScheme.surface,
+              labelText: "Email",
+
+
+            ),
+          ),                
+        ],
+    ));
+    } 
+
+    return Column(
+      children: children,
     );
+
   }
+
+  String? requiredAndMin3(value) {
+          if(value == null || value.trim() == ''){
+            return "Campo obligatorio";
+          }
+          if(value.length < 3){
+            return "Por lo menos 3 caracteres.";
+          }
+  
+          return null;
+        }
 }

--- a/lib/presentation/admin/session_manager_screen/widgets/calendar_side_column.dart
+++ b/lib/presentation/admin/session_manager_screen/widgets/calendar_side_column.dart
@@ -15,52 +15,48 @@ class CalendarSideColumn extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-          width: 300,
-          child: Column(
-            children: [
-              const SizedBox(height: 80, child: SessionManagerDayCarrousel()),
-              const SizedBox(
-                height: 8,
-              ),
-              const Divider(),
-              const SizedBox(
-                height: 8,
-              ),
-              Container(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(25),
-                    //boxShadow: [BoxShadow(blurRadius: 5, spreadRadius: 5, color: Theme.of(context).colorScheme.shadow.withOpacity(0.2))],
-                  ),
-                  width: 300,
-                  child: calendarDatepicker2(context)),
-              const SizedBox(
-                height: 8,
-              ),
-              const Divider(),
-              const Spacer(),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  SizedBox(
-                    height: 36,
-                    child: FilledButton(
-                        onPressed: () {
-                          context.go('/add_sessions');
-                        }, 
-                        child: const Text("Agregar Turnos")),
-                  ),
-                  SizedBox(
-                    height: 36,
-                    child: TextButton(
-                        onPressed: () {},
-                        child: const Text("Secondary option")),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        );
+    return Column(
+      children: [
+        const SizedBox(height: 80, child: SessionManagerDayCarrousel()),
+        const SizedBox(
+          height: 8,
+        ),
+        const Divider(),
+        const SizedBox(
+          height: 8,
+        ),
+        Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(25),
+            ),
+            width: 300,
+            child: calendarDatepicker2(context)),
+        const SizedBox(
+          height: 8,
+        ),
+        const Divider(),
+        const Spacer(),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            SizedBox(
+              height: 36,
+              child: FilledButton(
+                  onPressed: () {
+                    context.go('/add_sessions');
+                  }, 
+                  child: const Text("Agregar Turnos")),
+            ),
+            SizedBox(
+              height: 36,
+              child: TextButton(
+                  onPressed: () {},
+                  child: const Text("Secondary option")),
+            ),
+          ],
+        ),
+      ],
+    );
   }
 }
 

--- a/lib/presentation/admin/session_manager_screen/widgets/session_manager_card.dart
+++ b/lib/presentation/admin/session_manager_screen/widgets/session_manager_card.dart
@@ -118,11 +118,8 @@ class NotReservedSessionCard extends StatelessWidget {
               color: Theme.of(context).colorScheme.tertiary,
               width: 16,
             ),
-            const SizedBox(
-              width: 4,
-            ),
             Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              padding: const EdgeInsets.all( 8.0),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [

--- a/lib/presentation/admin/session_manager_screen/widgets/session_manager_day_carrousel.dart
+++ b/lib/presentation/admin/session_manager_screen/widgets/session_manager_day_carrousel.dart
@@ -9,7 +9,9 @@ import '../../bloc/session_manager_event.dart';
 import '../../bloc/session_manager_state.dart';
 
 class SessionManagerDayCarrousel extends StatelessWidget {
-  const SessionManagerDayCarrousel({super.key});
+  const SessionManagerDayCarrousel({super.key, this.width = 300});
+
+  final double width;
 
   @override
   Widget build(BuildContext context) {
@@ -19,6 +21,7 @@ class SessionManagerDayCarrousel extends StatelessWidget {
         return DatesCarrousel(
           datesCarrouselController: sl<SessionManagerBloc>().datesCarrouselController ,
           initialDate: state.currentDate,
+          containerWidth: width,
           onSelect: (date) {
             sl<SessionManagerBloc>().add(SessionChangeDateEvent(date));
           },

--- a/lib/presentation/core/agenda/agenda.dart
+++ b/lib/presentation/core/agenda/agenda.dart
@@ -3,8 +3,10 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import '../../../core/utils/responsive_builder.dart';
+import '../../../core/utils/types/time_interval.dart';
 import '../../../domain/entities/physical_partition.dart';
 import '../../../domain/entities/session.dart';
 
@@ -352,16 +354,26 @@ class Agenda extends StatelessWidget {
           double offsetFinal = 0;
 
           final currentSession = currentPhysicalPartitionSessions[index];
-          late final Session previousSession;
 
           final int duration = currentSession.getDurationInMinutes();
-          late final int previousDuration;
+
+          int? previousDuration;
+          Session? previousSession;
+          
+          DateTime previousBlankSpaceStartTime;
 
 
           if(index != 0){
             previousSession = currentPhysicalPartitionSessions[index - 1];
             previousDuration = previousSession.getDurationInMinutes();
+            previousBlankSpaceStartTime = previousSession.endTime;
+          } else {
+            previousBlankSpaceStartTime = horariosDisponibles[0];
           }
+
+     
+
+          
           
 
           if (index == 0) {
@@ -370,11 +382,15 @@ class Agenda extends StatelessWidget {
                     .inMinutes
                     .abs() *
                 heightPerMinute;
+
+            
           } else {
-            offsetPrevio = (currentSession.startTime.difference(currentPhysicalPartitionSessions[index - 1].startTime).inMinutes.abs() - previousDuration) * heightPerMinute;
+            offsetPrevio = (currentSession.startTime.difference(currentPhysicalPartitionSessions[index - 1].startTime).inMinutes.abs() - previousDuration!) * heightPerMinute;
           }
 
           if (index == currentPhysicalPartitionSessions.length - 1) {
+            
+
             offsetFinal = (currentSession.startTime
                         .difference(
                             horariosDisponibles[horariosDisponibles.length - 1])
@@ -388,7 +404,7 @@ class Agenda extends StatelessWidget {
 
           if(offsetPrevio < 0){
 
-            showErrorMessage(previousSession, currentSession, context);
+            showErrorMessage(previousSession!, currentSession, context);
                       
             return const SizedBox();
           }
@@ -406,7 +422,16 @@ class Agenda extends StatelessWidget {
                   height: 15 * heightPerMinute,
                 ),
                 if(offsetPrevio > 0)
-                  BlankSpace(height: offsetPrevio, minHeightToHover: 90 * heightPerMinute,),
+                  BlankSpace(
+                    canHover: true,
+                    height: offsetPrevio, 
+                    minHeightToHover: 90 * heightPerMinute, 
+                    physicalPartition: physicalPartition,
+                    blankSpaceTimeInterval: TimeInterval(
+                      initialDate: previousBlankSpaceStartTime,
+                      endDate: currentSession.startTime
+                    ),
+                  ),
 
                 SizedBox(
                     height: duration * heightPerMinute.toDouble() -
@@ -417,8 +442,14 @@ class Agenda extends StatelessWidget {
 
                 if (index == currentPhysicalPartitionSessions.length - 1)
                   BlankSpace(
+                    canHover: true,
                     height: offsetFinal.toDouble(),
                     minHeightToHover: 90 * heightPerMinute,
+                    physicalPartition: physicalPartition,
+                    blankSpaceTimeInterval: TimeInterval(
+                      initialDate: currentSession.endTime,
+                      endDate: horariosDisponibles.last
+                    ),
                   ),
               ],
             ),
@@ -441,17 +472,22 @@ class Agenda extends StatelessWidget {
 }
 
 class BlankSpace extends StatefulWidget {
-  const BlankSpace({
-    super.key,
+    
+    const BlankSpace({
+    super.key, 
+    required this.canHover,
     required this.height,
-    this.canHover = true,
     required this.minHeightToHover,
-
+    this.blankSpaceTimeInterval, 
+    this.physicalPartition
   });
+
 
   final bool canHover;
   final double height;
   final double minHeightToHover;
+  final TimeInterval? blankSpaceTimeInterval;
+  final PhysicalPartition? physicalPartition;
 
 
   @override
@@ -475,8 +511,11 @@ class _BlankSpaceState extends State<BlankSpace> {
 
     Widget childNotHovered = const Center(child: SizedBox());
 
+    DateFormat dateFormat = DateFormat("HH:mm");
+
     return MouseRegion(
       cursor: SystemMouseCursors.click,
+
       onEnter: (event) {
         setState(() {
           isHovered = true;
@@ -491,7 +530,16 @@ class _BlankSpaceState extends State<BlankSpace> {
         color: Colors.transparent,
         child: InkWell(
           onTap: () {
-            
+            context.goNamed(
+              "SESSION_MANAGER_ADD",
+              pathParameters:{
+                "idPhysicalPartition":widget.physicalPartition!.partitionPhysicalId.toString()
+              },
+              queryParameters: {
+                "start": dateFormat.format(widget.blankSpaceTimeInterval!.initialDate!),
+                'end':dateFormat.format(widget.blankSpaceTimeInterval!.endDate!)
+              },
+            );
           },
           child: SizedBox(
             height: widget.height.toDouble(),
@@ -500,9 +548,7 @@ class _BlankSpaceState extends State<BlankSpace> {
               child: Center(
                 child: isHovered ? childHovered : childNotHovered,
               ),
-            )
-            
-             
+            )                       
           ),
         ),
       ));

--- a/lib/presentation/core/agenda/agenda.dart
+++ b/lib/presentation/core/agenda/agenda.dart
@@ -19,7 +19,9 @@ class Agenda extends StatelessWidget {
       required this.physicalPartitions,
       required this.fromDate,
       required this.lastDate,
-      this.columnWidth = 300}) {
+      this.columnWidth = 300
+      
+      })  {
     horariosDisponibles = generateDates(fromDate, lastDate);
     scrollControllers = generateScrollControllers();
     initializeScrollControllerListeners();
@@ -172,7 +174,7 @@ class Agenda extends StatelessWidget {
   // Es una lista vertical que ocupa todo el alto. 
   // Para cuando es necesario tener una lista vacia, para que ese espacio siga pudiendose scrollear.
  
-  Widget buildEmptyList(ScrollController controller) {
+  Widget buildEmptyList(ScrollController controller, [PhysicalPartition? physicalPartition]) {
     return ListView.builder(
             controller: controller,
             itemCount: 1,
@@ -181,13 +183,15 @@ class Agenda extends StatelessWidget {
               final height = horariosDisponibles.first.difference(horariosDisponibles.last).inMinutes.abs() * heightPerMinute;
               
               return BlankSpace(
-                canHover: false,
+                canHover: physicalPartition?.durationInMinutes != null,
                 height: height + 80,
                 minHeightToHover: 0,
+                physicalPartition: physicalPartition,
+                blankSpaceTimeInterval: TimeInterval(initialDate: horariosDisponibles.first, endDate: horariosDisponibles.last),
               );
             },                                    
         );
-  }
+  } 
 
   Column cardsLists(BuildContext context) {
     return Column(
@@ -340,7 +344,7 @@ class Agenda extends StatelessWidget {
     if (currentPhysicalPartitionSessions.isEmpty) {
       return SizedBox(
         width: columnWidth.toDouble(),
-        child: buildEmptyList(scrollControllers[physicalPartitions.indexOf(physicalPartition)]) ,
+        child: buildEmptyList(scrollControllers[physicalPartitions.indexOf(physicalPartition)], physicalPartition) ,
         
       );
     }
@@ -423,9 +427,9 @@ class Agenda extends StatelessWidget {
                 ),
                 if(offsetPrevio > 0)
                   BlankSpace(
-                    canHover: true,
+                    canHover: physicalPartition.durationInMinutes != null,
                     height: offsetPrevio, 
-                    minHeightToHover: 90 * heightPerMinute, 
+                    minHeightToHover: (physicalPartition.durationInMinutes ?? 0) * heightPerMinute, 
                     physicalPartition: physicalPartition,
                     blankSpaceTimeInterval: TimeInterval(
                       initialDate: previousBlankSpaceStartTime,
@@ -442,9 +446,9 @@ class Agenda extends StatelessWidget {
 
                 if (index == currentPhysicalPartitionSessions.length - 1)
                   BlankSpace(
-                    canHover: true,
+                    canHover: physicalPartition.durationInMinutes != null,
                     height: offsetFinal.toDouble(),
-                    minHeightToHover: 90 * heightPerMinute,
+                    minHeightToHover: (physicalPartition.durationInMinutes ?? 0) * heightPerMinute, 
                     physicalPartition: physicalPartition,
                     blankSpaceTimeInterval: TimeInterval(
                       initialDate: currentSession.endTime,

--- a/lib/presentation/core/custom_time_picker.dart
+++ b/lib/presentation/core/custom_time_picker.dart
@@ -15,8 +15,14 @@ class CustomTimePicker extends StatefulWidget {
   final bool isLastInput;
 
   const CustomTimePicker({
-    super.key, this.initialHours, this.initialMinutes, this.onChange, required this.name, this.autoFocus = false, 
-    this.focusNode, this.onSubmit,
+    super.key, 
+    this.initialHours, 
+    this.initialMinutes, 
+    this.onChange, 
+    required this.name, 
+    this.autoFocus = false, 
+    this.focusNode, 
+    this.onSubmit,
     this.isLastInput = false
   });
 
@@ -39,7 +45,7 @@ class _CustomTimePickerState extends State<CustomTimePicker> {
 
   @override
   void initState() {
-    // TODO: implement initState
+    
     hoursController.text = widget.initialHours ?? '';
     minutesController.text = widget.initialMinutes ?? '';
  
@@ -114,11 +120,10 @@ class _CustomTimePickerState extends State<CustomTimePicker> {
               
               ),
             ),
-            Container(
-              margin: const EdgeInsets.symmetric(horizontal: 8),
+            SizedBox(
               height: 80,
-              child:const Text(":", style: TextStyle(fontSize: 40),),
-            ),
+              width: 25,
+              child: const Text(":", style: TextStyle(fontSize: 40 ), textAlign: TextAlign.center,)),
             SizedBox(
               height: 100,
               width: 100,

--- a/lib/presentation/feed/widgets/turno_card.dart
+++ b/lib/presentation/feed/widgets/turno_card.dart
@@ -58,7 +58,7 @@ class SessionCard extends StatelessWidget {
                 Icons.timer_sharp,
                 size: 18,
               ),
-              Text(session.duration!)
+              Text(session.duration.toString())
             ]),
             const SizedBox(height: 5),
             const Row(children: [

--- a/lib/presentation/turno/turno_page.dart
+++ b/lib/presentation/turno/turno_page.dart
@@ -11,7 +11,7 @@ class SessionPage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(),
       body: Center(
-        child: Text(session.duration!),
+        child: Text(session.duration.toString()),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   freezed_annotation: ^2.4.1
   flutter_portal: ^1.1.4
   flutter_localization: ^0.2.0
+  collection: ^1.18.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Descripción

Implementación de formulario para creación de nuevos turnos desde el session manager

## Explicacion
![image](https://github.com/jeremanuel/turni/assets/60302223/9ac2044c-cac3-40cc-9956-e0f8d78058e7)

En los espacios en blanco entre turnos, se puede clickear (en hover, se ve así).
Hay un mínimo configurable, para que si son espacios chicos, no pase esto.

![image](https://github.com/jeremanuel/turni/assets/60302223/f269addf-56ff-4af4-b871-ecbf962c5aa4)

Al clickear un espacio, la ruta cambia, redibujándose la última columna, con el formulario.

La hora de inicio, y la duración, ya aparecen seteadas según el espacio que se clickeo. 

Lo mismo con la cancha (la cual no se puede cambiar igualmente).

Estos datos viajan en la URL.

EJ:  
**http://localhost:1234/#/session_manager/add/1?start=13:00&end=15:00**

el /1 es el idPhysicalPartition.

Este enfoque con las rutas, nos va a traer ventajas a la hora de buscar implementar deep links (aunque para este formulario no seria interesante, pero si para el formulario de reservar un turno)

![image](https://github.com/jeremanuel/turni/assets/60302223/87e413db-9fec-4794-855f-0fdb31a758b9)

Esta parte del formulario, es para elegir el cliente (opcional en este caso, ya que se podría agregar un turno sin cliente)


Este componente para elegir un cliente (Nuevo o existente) se va a reutilizar en muchos lugares, como al clickear "reservar" sobre una card.

Al clickear en buscar, desplegamos una AnchorSearch basada en https://m3.material.io/components/search/guidelines.

![image](https://github.com/jeremanuel/turni/assets/60302223/aad02db5-a90d-49f9-9280-cbe091da16e8)

Si seleccionamos un cliente de la busqueda, se veria asi:

![image](https://github.com/jeremanuel/turni/assets/60302223/27007d70-9241-4e62-9ded-8b5c511868d5)


En el caso de "Crear" habría que mostrar un formulario con los datos básicos para crear un cliente. 

Nombre, Apellido, email (opcional?), telefono (opcional?)

![image](https://github.com/jeremanuel/turni/assets/60302223/2000659e-8c33-45de-9b03-864e9d468806)

Algo asi.


Estaba pensando que sería útil, a nivel de ClubPartition o ClubPhysicalPartition, almacenar una duración, para ya saber que todos los turnos de esas ClubPartition./ClubPhysicalPartition duran ese tiempo, para todos los formularios de estas creaciones ya vengan con ese valor seteado.

También tengo que agregar el precio. Igualmente, creo que el precio en los turnos sería algo opcional, que si esta cargado, podemos mostrarle al cliente en la APP, pero no se si obligar a que se cargue siempre, al menos hasta que tengamos implementado tema de tarifas, etc.



## Comprobación

Antes de enviar este PR, por favor, asegúrate de que has realizado las siguientes comprobaciones:

- [x] Me he asignado como responsable del PR.
- [x] He añadido etiquetas si es necesario.
- [x] He probado este código en mi entorno local.
- [] He agregado documentación si es necesario.
- [ ] He agregado test unitarios.


## Merge Strategy

| From | To | Strategy |
|--------|--------|--------|
| Feature | Develop | Squash&Merge |
| Release | Master | Merge Commit |
| Hotfix | Master | Squash&Merge | 

